### PR TITLE
BugFixed : : submitScore to play services is corrected

### DIFF
--- a/Classes/JNIHelpers.cpp
+++ b/Classes/JNIHelpers.cpp
@@ -80,13 +80,14 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath, const char* arg0, long score) {
     cocos2d::JniMethodInfo minfo;
 
-    bool isHave = cocos2d::JniHelper::getStaticMethodInfo(minfo,classPath,methodName, "(Ljava/lang/String;Z)V");
+    bool isHave = cocos2d::JniHelper::getStaticMethodInfo(minfo,classPath,methodName, "(Ljava/lang/String;J)V");
 
     if (isHave) 
 	{
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
+        jlong scoreArg1    = score;
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0, score);
+        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0, scoreArg1);
 
 		minfo.env->DeleteLocalRef(stringArg0);
 


### PR DESCRIPTION
1. Submit score to play services was not working properly before because of call to bad function signature in JNIHelper.cpp which is corrected now.
2. 'long score' was taking garbage value as not converted to jlong is also fixed.
