### PR TITLE
Function signature corrected for incrementAchievement in JNIHelper

### DIFF
--- a/Classes/JNIHelpers.cpp
+++ b/Classes/JNIHelpers.cpp
@@ -98,7 +98,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath, const char* arg0, int numSteps) {
     cocos2d::JniMethodInfo minfo;
 
-    bool isHave = cocos2d::JniHelper::getStaticMethodInfo(minfo,classPath,methodName, "(Ljava/lang/String;Z)V");
+    bool isHave = cocos2d::JniHelper::getStaticMethodInfo(minfo,classPath,methodName, "(Ljava/lang/String;I)V");
 
     if (isHave) 
 	{


### PR DESCRIPTION
incrementAchievement : function call done for Boolean instead of Integer is corrected now. 
