### PR TITLE
return type of CallStaticIntMethod does not match

### DIFF
--- a/GooglePlayGameServices/Classes/JNIHelpers.cpp
+++ b/GooglePlayGameServices/Classes/JNIHelpers.cpp
@@ -61,7 +61,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 	{
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0);
+        minfo.env->CallStaticVoidMethod(minfo.classID, minfo.methodID, stringArg0);
 
 		minfo.env->DeleteLocalRef(stringArg0);
     }
@@ -78,7 +78,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 	{
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0, looping);
+        minfo.env->CallStaticVoidMethod(minfo.classID, minfo.methodID, stringArg0, looping);
 
 		minfo.env->DeleteLocalRef(stringArg0);
 
@@ -97,7 +97,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
         jlong scoreArg1    = score;
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0, scoreArg1);
+        minfo.env->CallStaticVoidMethod(minfo.classID, minfo.methodID, stringArg0, scoreArg1);
 
 		minfo.env->DeleteLocalRef(stringArg0);
 
@@ -115,7 +115,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 	{
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0, numSteps);
+        minfo.env->CallStaticVoidMethod(minfo.classID, minfo.methodID, stringArg0, numSteps);
 
 		minfo.env->DeleteLocalRef(stringArg0);
 


### PR DESCRIPTION
Calling submitScore returned a exception because in some of the JniHelpers::jniCommonVoidCall methods there was CallStaticIntMethod instead of CallStaticVoidMethod.
