### PR TITLE
Changed minfo.env->CallStaticIntMethod to minfo.env->CallStaticVoidMe…

### DIFF
--- a/GooglePlayGameServices/Classes/JNIHelpers.cpp
+++ b/GooglePlayGameServices/Classes/JNIHelpers.cpp
@@ -61,7 +61,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 	{
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0);
+        minfo.env->CallStaticVoidMethod(minfo.classID, minfo.methodID, stringArg0);//CallStaticIntMethod => CallStaticVoidMethod
 
 		minfo.env->DeleteLocalRef(stringArg0);
     }
@@ -97,7 +97,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
         jlong scoreArg1    = score;
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0, scoreArg1);
+        minfo.env->CallStaticVoidMethod(minfo.classID, minfo.methodID, stringArg0, scoreArg1);//CallStaticIntMethod => CallStaticVoidMethod
 
 		minfo.env->DeleteLocalRef(stringArg0);
 
@@ -115,7 +115,7 @@ void JniHelpers::jniCommonVoidCall(const char* methodName, const char* classPath
 	{
 		jstring stringArg0 = minfo.env->NewStringUTF(arg0);
 
-        minfo.env->CallStaticIntMethod(minfo.classID, minfo.methodID, stringArg0, numSteps);
+        minfo.env->CallStaticVoidMethod(minfo.classID, minfo.methodID, stringArg0, numSteps);//CallStaticIntMethod => CallStaticVoidMethod
 
 		minfo.env->DeleteLocalRef(stringArg0);
 


### PR DESCRIPTION
…thod inside JniHelpers::jniCommonVoidCall . It fixes the runtime error caused while calling some Google Play methods like show achievements, submit score.
